### PR TITLE
Add support for anonymous enums

### DIFF
--- a/GAS/cc_x86.S
+++ b/GAS/cc_x86.S
@@ -752,6 +752,23 @@ fputc:
 
 Output_file_address: .word Output_file
 
+enum_error_open_curly: .asciz "ERROR in enum\nExpected {\n"
+.balign 4
+enum_error_equal: .asciz "ERROR in enum\nExpected =\n"
+.balign 4
+enum_error_close_curly: .asciz "ERROR in enum\nExpected }\n"
+.balign 4
+enum_error_semi_colon: .asciz "ERROR in enum\nExpected ;\n"
+.balign 4
+
+open_curly_brace_program: .asciz "{"
+.balign 4
+comma_program: .asciz ","
+.balign 4
+equal_program: .asciz "="
+.balign 4
+close_curly_brace_program: .asciz "}"
+.balign 4
 
 ## program function
 ## receives nothing, returns nothing
@@ -762,6 +779,98 @@ program:
 	push {r2}                           @ Protect R2
 
 new_type:
+	ldr r0, [r12]                       @ Using global_token
+	cmp r0, #0                          @ Check if NULL
+	beq program_done                    @ Be done if null
+
+	ldr r1, [r0, #8]                    @ GLOBAL_TOKEN->S
+	adr r0, enum                        @ "enum"
+	push {r14}
+	bl match                            @ IF GLOBAL_TOKEN->S == "enum"
+	pop {r14}
+	cmp r0, #0                          @ If true
+	bne constant_value                  @ Looks like not an enum
+
+	## Deal with minimal anonymous enums
+	ldr r0, [r12]                       @ Using global_token
+	ldr r0, [r0]                        @ global_token->next
+	str r0, [r12]                       @ global_token = global_token->next
+
+	adr r0, enum_error_open_curly       @ Using "ERROR in statement\nMissing {\n"
+	adr r1, open_curly_brace_program    @ Using "{"
+	push {r14}
+	bl require_match                    @ Make sure it has the required
+	pop {r14}
+
+enumerator:
+	ldr r0, [r12]                       @ Using global_token->s
+	ldr r0, [r0, #8]
+	mov r1, #0                          @ NULL
+	ldr r8, global_constant_list_address
+	ldr r2, [r8]                        @ global_constant_list
+	push {r14}
+	bl sym_declare                      @ Declare that constant
+	pop {r14}
+	ldr r8, global_constant_list_address
+	str r0, [r8]                        @ global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	ldr r0, [r12]                       @ Using global_token
+	ldr r0, [r0]                        @ global_token->next
+	str r0, [r12]                       @ global_token = global_token->next
+
+	adr r0, enum_error_equal            @ Using "ERROR in statement\nMissing =\n"
+	adr r1, equal_program               @ Using "="
+	push {r14}
+	bl require_match                    @ Make sure it has the required
+	pop {r14}
+
+	ldr r1, [r12]                       @ Using global_token
+	ldr r0, global_constant_list_address
+	ldr r0, [r0]
+	str r1, [r0, #16]                   @ global_constant_list->arguments = global_token
+
+	ldr r0, [r12]                       @ Using global_token
+	ldr r0, [r0]                        @ global_token->next
+	str r0, [r12]                       @ global_token = global_token->next
+
+	ldr r1, [r0, #8]                    @ global_token->s
+	adr r0, comma_program               @ ","
+	push {r14}
+	bl match                            @ IF GLOBAL_TOKEN->S == ","
+	pop {r14}
+	cmp r0, #0                          @ If true
+	bne enum_end                        @ No comma means no more enumerators
+
+	@ Skip comma
+	ldr r0, [r12]                       @ Using global_token
+	ldr r0, [r0]                        @ global_token->next
+	str r0, [r12]                       @ global_token = global_token->next
+
+	@ Check if there are more enumerators or if it was a trailing comma
+	ldr r1, [r0, #8]                    @ GLOBAL_TOKEN->S
+	adr r0, close_curly_brace_program   @ "}"
+	push {r14}
+	bl match                            @ IF GLOBAL_TOKEN->S == "}"
+	pop {r14}
+	cmp r0, #0                          @ If true
+	bne enumerator                      @ More enumerators
+
+enum_end:
+	adr r0, enum_error_close_curly      @ Using "ERROR in statement\nMissing }\n"
+	adr r1, close_curly_brace_program   @ Using "}"
+	push {r14}
+	bl require_match                    @ Make sure it has the required
+	pop {r14}
+
+	adr r0, enum_error_semi_colon       @ Using "ERROR in statement\nMissing ;\n"
+	adr r1, semicolon_0                 @ Using ";"
+	push {r14}
+	bl require_match                    @ Make sure it has the required
+	pop {r14}
+
+	b new_type                          @ go around again
+
+constant_value:
 	ldr r0, [r12]                       @ Using global_token
 	cmp r0, #0                          @ Check if NULL
 	beq program_done                    @ Be done if null
@@ -890,6 +999,8 @@ program_string_1: .asciz "\nNULL\n"
 semicolon_0: .asciz ";"
 .balign 4
 open_paren_0: .asciz "("
+.balign 4
+enum: .asciz "enum"
 .balign 4
 constant: .asciz "CONSTANT"
 .balign 4


### PR DESCRIPTION
@stikonas 

The duplicated symbols are necessary because `adr` is PC relative and can't be outside of a certain range. The file is full of duplicated definitions.

Test file:
```c
// CONSTANT TEST5 5
enum {
    TEST1 = 1,
    TEST2 = 2
};

enum {
    TEST3 = 3,
    TEST4 = 4,
};

int main() {
    return TEST1 + TEST2 + TEST3 + TEST4 + TEST5;
}
```

Results in:
```
:FUNCTION_main
LOAD_IMMEDIATE_eax %1
PUSH_eax        #_common_recursion
LOAD_IMMEDIATE_eax %2
POP_ebx # _common_recursion
ADD_ebx_to_eax
PUSH_eax        #_common_recursion
LOAD_IMMEDIATE_eax %3
POP_ebx # _common_recursion
ADD_ebx_to_eax
PUSH_eax        #_common_recursion
LOAD_IMMEDIATE_eax %4
POP_ebx # _common_recursion
ADD_ebx_to_eax
PUSH_eax        #_common_recursion
LOAD_IMMEDIATE_eax %5
POP_ebx # _common_recursion
ADD_ebx_to_eax
RETURN

:ELF_end
```